### PR TITLE
Ensure we use Time from stdlib

### DIFF
--- a/lib/lita-asset-track.rb
+++ b/lib/lita-asset-track.rb
@@ -24,7 +24,7 @@ module Lita
             Lita::Timing::RateLimit.new("lita-asset-track", redis).once_every(HOUR) do
               redis.sscan_each(MANIFEST_SET_KEY).map { |manifest_url|
                 URI(manifest_url).tap { |uri|
-                  uri.query = URI.encode_www_form("t" => Time.now.to_i)
+                  uri.query = URI.encode_www_form("t" => ::Time.now.to_i)
                 }
               }.each { |manifest_uri|
                 manifest_json = JSON.parse Net::HTTP.get(manifest_uri)


### PR DESCRIPTION
Some lita installations use the [lita-time plugin](https://rubygems.org/gems/lita-time), which results in the following execption:

> NoMethodError undefined method `now' for Lita::Handlers::Time:Class